### PR TITLE
SN: Change the mmddyyyy to yyyy-mm-dd

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Shreedevisnow.
 Atul-LNG.
 Beeram12.
 Charanjet.
+jahnaviT2003.
 KedarisettiSreeVamsi.
 soham-shee.
 tejasathalye.
@@ -248,7 +249,6 @@ d7ianielsimonP.
 DennisRutherford.
 Gowthamsai29.
 Itsreema.
-jahnaviT2003.
 manrick.
 marcos-michalski.
 mebeingmustaq.
@@ -598,6 +598,7 @@ Atul-LNG.
 Beeram12.
 Charanjet.
 crooks-s.
+jahnaviT2003.
 Jaskaran-Techno.
 KedarisettiSreeVamsi.
 osc99.
@@ -635,9 +636,9 @@ j4rodm.
 jamesfoot.
 JBscriptsNow.
 JingAlanzhixin.
-jordanrogus.
 
 **Other contributors:**
+jordanrogus.
 Juusoee.
 KartikeSingh.
 kaushalbharade.
@@ -739,7 +740,6 @@ HariniSnow.
 himanisinghal.
 ishanjain18.
 Itsreema.
-jahnaviT2003.
 javiervillarreal.
 jaz1gdev.
 JCofman.

--- a/README.md
+++ b/README.md
@@ -200,20 +200,20 @@ mo-dahir.
 SNProductOwner.
 dcord1x.
 Dhruvyadav2000.
+jahnaviT2003.
 kylburns89.
 shraddhakadam301298.
 debendu-das.
 riya-misra-1.
-Saileshlanka.
 
 **Other contributors:**
+Saileshlanka.
 bhavyajain511.
 Paulsylo25.
 Shreedevisnow.
 Atul-LNG.
 Beeram12.
 Charanjet.
-jahnaviT2003.
 KedarisettiSreeVamsi.
 soham-shee.
 tejasathalye.
@@ -564,6 +564,7 @@ allam1234.
 Decoder-Paul.
 DhanushNehru.
 Dhruvyadav2000.
+jahnaviT2003.
 jesalynrose.
 kylburns89.
 Ladirinia.
@@ -598,7 +599,6 @@ Atul-LNG.
 Beeram12.
 Charanjet.
 crooks-s.
-jahnaviT2003.
 Jaskaran-Techno.
 KedarisettiSreeVamsi.
 osc99.

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ ynr-ram.
 aswamy93.
 selvarun-umass.
 bkb68.
-sravankadudhuri.
 ashoo-jindal.
+sravankadudhuri.
 maheshkhatal27.
 bird-03.
 templetontsai.
@@ -369,12 +369,12 @@ urspvs.
 Radhe-Manasa.
 kmxo.
 aykmrgit.
+ashoo-jindal.
 chetnadev.
 stevezero.
 sychi77.
 azeezgaa.
 deepak-64742.
-ashoo-jindal.
 rafzk.
 anillande90.
 ayleeandersen.

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ eriemer1.
 Mexiprince.
 at8807602.
 chetnadev.
+Vishnu-rvk.
 
 **Top 50% contributors:**
-Vishnu-rvk.
 himanshu7895.
 isaac-vicentini.
 jahnaviT2003.
@@ -205,9 +205,9 @@ Dhruvyadav2000.
 kylburns89.
 shraddhakadam301298.
 debendu-das.
+riya-misra-1.
 
 **Other contributors:**
-riya-misra-1.
 Saileshlanka.
 bhavyajain511.
 Paulsylo25.
@@ -283,6 +283,7 @@ ersureshbe.
 gauravghodinde.
 girishnagaraj09.
 GittyHarsha.
+GP-UOB.
 herambchaudhari4121.
 Jahnavi-Solanki.
 jefflintel.
@@ -962,6 +963,7 @@ GLaDOS2199.
 golu833.
 GouthamSG.
 Gowthammadhusuthanan067.
+GP-UOB.
 greenc123.
 greencarlos.
 GTKsnow.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ chetnadev.
 Vishnu-rvk.
 himanshu7895.
 isaac-vicentini.
+jahnaviT2003.
 priyasnexpert.
 S-w-a-p-n-i-l-22.
 naveenraw25.
@@ -200,7 +201,6 @@ mo-dahir.
 SNProductOwner.
 dcord1x.
 Dhruvyadav2000.
-jahnaviT2003.
 kylburns89.
 shraddhakadam301298.
 debendu-das.
@@ -538,6 +538,7 @@ yourepicservices.
 ChecksumFailed.
 
 **Top 50% contributors:**
+jahnaviT2003.
 markroethof.
 priyasnexpert.
 S-w-a-p-n-i-l-22.
@@ -564,7 +565,6 @@ allam1234.
 Decoder-Paul.
 DhanushNehru.
 Dhruvyadav2000.
-jahnaviT2003.
 jesalynrose.
 kylburns89.
 Ladirinia.

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ shashwatmishraog.
 simt0m.
 singhaditya73.
 SKYsnaX.
+spnegi.
 Srikanth1306.
 steveuncg.
 stwinkle.
@@ -634,9 +635,9 @@ j4rodm.
 jamesfoot.
 JBscriptsNow.
 JingAlanzhixin.
+jordanrogus.
 
 **Other contributors:**
-jordanrogus.
 Juusoee.
 KartikeSingh.
 kaushalbharade.
@@ -1244,6 +1245,7 @@ somusekher.
 Sookeyy-12.
 Soulpancake000.
 Souradeephazra123.
+spnegi.
 Srikanth1306.
 srirampusuluri1.
 Srutip04.

--- a/README.md
+++ b/README.md
@@ -192,10 +192,10 @@ isaac-vicentini.
 priyasnexpert.
 S-w-a-p-n-i-l-22.
 naveenraw25.
+sandeepd26.
 VaishnaviLathkar98.
 dadhich-ashish.
 Rampriya-S.
-sandeepd26.
 mo-dahir.
 SNProductOwner.
 dcord1x.
@@ -513,6 +513,7 @@ mandeepkaran.
 Mexiprince.
 riya-vermaa.
 Saileshlanka.
+sandeepd26.
 allenandreas.
 anubhav-ritolia.
 apple9000.
@@ -522,7 +523,6 @@ odinsride.
 piyusalunke123.
 rene-el.
 rmedved84.
-sandeepd26.
 src107.
 fn20200323.
 pratyushasndev.

--- a/README.md
+++ b/README.md
@@ -199,19 +199,19 @@ dadhich-ashish.
 Rampriya-S.
 mo-dahir.
 SNProductOwner.
+Atul-LNG.
 dcord1x.
 Dhruvyadav2000.
 kylburns89.
 shraddhakadam301298.
 debendu-das.
-riya-misra-1.
 
 **Other contributors:**
+riya-misra-1.
 Saileshlanka.
 bhavyajain511.
 Paulsylo25.
 Shreedevisnow.
-Atul-LNG.
 Beeram12.
 Charanjet.
 KedarisettiSreeVamsi.
@@ -562,6 +562,7 @@ sonamtiwari8.
 Adiana3308.
 akhoshnood.
 allam1234.
+Atul-LNG.
 Decoder-Paul.
 DhanushNehru.
 Dhruvyadav2000.
@@ -595,7 +596,6 @@ Shreedevisnow.
 sisco0.
 yuvraj1107thapa.
 ashaw7697.
-Atul-LNG.
 Beeram12.
 Charanjet.
 crooks-s.


### PR DESCRIPTION
Hi All,

I am using excel parser and I am getting date values in the data and the date values are given in format "mm/dd/yyyy" However we need in format "yyyy-mm-dd" format in order to map the values to the field in ServiceNow Hence I used this conversion to make it dynamic update from Excel to ServiceNow.

This works in Global and scoped Application.

Regards,
Shamma
[Change the mmddyyyy to yyyy-mm-dd.zip](https://github.com/user-attachments/files/17278549/Change.the.mmddyyyy.to.yyyy-mm-dd.zip)
[Change the mmddyyyy to yyyy-mm-dd.zip](https://github.com/user-attachments/files/17278550/Change.the.mmddyyyy.to.yyyy-mm-dd.zip)
